### PR TITLE
Property details endpoint and minor documentation fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug API",
+            "type": "python",
+            "request": "launch",
+            "module": "flask",
+            "envFile": "${workspaceFolder}/.env",
+            "args": [
+                "run",
+                "--no-debugger"
+            ],
+            "jinja": false
+        }
+    ]
+}

--- a/src/controllers/properties.py
+++ b/src/controllers/properties.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from mongoengine.errors import OperationError, DoesNotExist
 
 import src.models.properties as m
@@ -61,3 +63,14 @@ def delete_prop(data, user_id) -> ControllerStatus:
         return ControllerStatus.ERROR
 
     return ControllerStatus.SUCCESS
+
+
+def get_property_data(prop_id: str) -> tuple[ControllerStatus, Optional[m.PropertyDoc]]:
+    try:
+        requested_prop = m.PropertyDoc.objects.get(id=prop_id)
+    except DoesNotExist:
+        return ControllerStatus.DOES_NOT_EXISTS, None
+    except OperationError:
+        return ControllerStatus.ERROR, None
+
+    return ControllerStatus.SUCCESS, requested_prop

--- a/src/controllers/upload.py
+++ b/src/controllers/upload.py
@@ -25,6 +25,10 @@ def upload_properties_photos(prop_id: str, user_id: str, photos: list[FileStorag
     except OperationError:
         return ControllerStatus.ERROR
 
+    # This is a safety check, uploading pictures to a property that already has them messes things up
+    if requested_prop.photo_list.first() is not None:
+        return ControllerStatus.ALREADY_EXISTS
+
     if str(requested_prop.owner.id) != user_id:
         return ControllerStatus.UNAUTHORIZED
 

--- a/src/controllers/upload.py
+++ b/src/controllers/upload.py
@@ -53,3 +53,8 @@ def get_photo_from_db(photo_id: str) -> tuple[ControllerStatus, Optional[ImageGr
         return ControllerStatus.DOES_NOT_EXISTS, None
 
     return ControllerStatus.SUCCESS, photo
+
+
+def merge_lists(lists: dict[str, FileStorage | list[FileStorage]]) -> list[FileStorage]:
+    return sum([[lists["main_photo"]], lists["photos"]], []) if "photos" in lists else [
+        lists["main_photo"]]

--- a/src/models/properties.py
+++ b/src/models/properties.py
@@ -27,6 +27,26 @@ class PropertyDoc(m.Document):
     meta = {"collection": "properties"}
 
 
+class PropertyDataResponse(Schema):
+    address = String()
+    description = String()
+    price = Float()
+    terrain_height = Float()
+    terrain_width = Float()
+    bed = Integer()
+    bath = Float()
+    floors = Integer()
+    garage = Integer()
+    contract = String()
+    currency = String()
+    owner = Nested(PropertyOwnerInfo, data_key="owner_info")
+    photo_ids = Function(lambda prop: [str(doc.photo.grid_id) for doc in prop.photo_list])
+
+
+class PropertyDataRequest(Schema):
+    id = String(required=True)
+
+
 class BasicPropertyRead(Schema):
     id = String(data_key="property_id")
     address = String()

--- a/src/models/properties.py
+++ b/src/models/properties.py
@@ -88,3 +88,9 @@ class UploadPhotosQueryRequest(Schema):
 class UploadPhotosFilesRequest(Schema):
     main_photo = Raw(type="string", format="binary", required=True)
     photos = List(Raw(type="string", format="binary"), validate=Length(max=9))
+
+
+class UploadPhotosRequest(Schema):
+    id = String()
+    main_photo = Raw(type="string", format="binary")
+    photos = List(Raw(type="string", format="binary"), validate=Length(max=9))

--- a/src/models/properties.py
+++ b/src/models/properties.py
@@ -27,10 +27,9 @@ class PropertyDoc(m.Document):
     meta = {"collection": "properties"}
 
 
-class PropertyRead(Schema):
+class BasicPropertyRead(Schema):
     id = String(data_key="property_id")
     address = String()
-    description = String()
     price = Float()
     terrain_height = Float()
     terrain_width = Float()
@@ -40,7 +39,7 @@ class PropertyRead(Schema):
     garage = Integer()
     contract = String()
     currency = String()
-    owner = Nested(PropertyOwnerInfo, data_key="owner_info")
+    owner_username = Function(lambda prop: prop.owner.username)
     thumbnail_id = Function(lambda prop: str(prop.photo_list.first().photo.thumbnail._id))
 
 

--- a/src/routes/properties.py
+++ b/src/routes/properties.py
@@ -75,6 +75,12 @@ def delete_property(data):
 @output(m.PropertyDataResponse)
 def get_property_data(data):
     result = c.get_property_data(data["id"])
+    if result[0] == ControllerStatus.DOES_NOT_EXISTS:
+        abort(404)
+
+    if result[0] == ControllerStatus.ERROR:
+        abort(500)
+
     return result[1]
 
 

--- a/src/routes/properties.py
+++ b/src/routes/properties.py
@@ -78,15 +78,11 @@ def delete_property(data):
 @auth_required(auth)
 # First parameter is the "hack" request, it serves no purpose internally
 def upload_property_photos(_, data, files):
-    verify_result = p.check_file_type(sum([[files["main_photo"]], files["photos"]], []) if "photos" in files else [
-        files["main_photo"]])
+    verify_result = p.check_file_type(p.merge_lists(files))
     if verify_result == ControllerStatus.NOT_AN_IMAGE:
         abort(400, "Endpoint only accepts JPG, PNG and WEBP images")
 
-    result = p.upload_properties_photos(data["id"],
-                                        auth.current_user["id"],
-                                        sum([[files["main_photo"]], files["photos"]], []) if "photos" in files else [
-                                            files["main_photo"]])
+    result = p.upload_properties_photos(data["id"], auth.current_user["id"], p.merge_lists(files))
     if result == ControllerStatus.DOES_NOT_EXISTS:
         abort(404)
 

--- a/src/routes/properties.py
+++ b/src/routes/properties.py
@@ -24,7 +24,7 @@ def create_property(data):
 
 
 @router.get("/properties")
-@output(m.PropertyRead(many=True), 200)
+@output(m.BasicPropertyRead(many=True), 200)
 @doc(summary='Get properties info')
 def read_property():
     result = c.all_props()

--- a/src/routes/properties.py
+++ b/src/routes/properties.py
@@ -70,6 +70,14 @@ def delete_property(data):
     return ""
 
 
+@router.get("/property")
+@input(m.PropertyDataRequest, location="query")
+@output(m.PropertyDataResponse)
+def get_property_data(data):
+    result = c.get_property_data(data["id"])
+    return result[1]
+
+
 @router.post("/property/photos")
 @input(m.UploadPhotosRequest)
 @input(m.UploadPhotosQueryRequest, location="form")

--- a/src/routes/properties.py
+++ b/src/routes/properties.py
@@ -99,6 +99,9 @@ def upload_property_photos(_, data, files):
     if result == ControllerStatus.NOT_AN_IMAGE:
         abort(400, "Endpoint only accepts JPG, PNG and WEBP images")
 
+    if result == ControllerStatus.ALREADY_EXISTS:
+        abort(400, "This property already has photos. Please, use the PUT endpoint (not existant yet, sorry)")
+
     return ""
 
 

--- a/src/routes/properties.py
+++ b/src/routes/properties.py
@@ -71,11 +71,13 @@ def delete_property(data):
 
 
 @router.post("/property/photos")
-@input(m.UploadPhotosQueryRequest, location="query")
+@input(m.UploadPhotosRequest)
+@input(m.UploadPhotosQueryRequest, location="form")
 @input(m.UploadPhotosFilesRequest, location="files")
 @output({}, 204)
 @auth_required(auth)
-def upload_property_photos(data, files):
+# First parameter is the "hack" request, it serves no purpose internally
+def upload_property_photos(_, data, files):
     verify_result = p.check_file_type(sum([[files["main_photo"]], files["photos"]], []) if "photos" in files else [
         files["main_photo"]])
     if verify_result == ControllerStatus.NOT_AN_IMAGE:


### PR DESCRIPTION
Now the API has a distinction between basic data (information that appears on the cards) and the whole property data (information that appears on the details page). Note that this endpoint is missing the profile data.

Also, the broken "Try it out" section of the photos' endpoint now works, almost. If you don't send extra photos, you must uncheck the "Send empty value" checkbox due to a validator bug.